### PR TITLE
Exported PDFs now reflect selected variables

### DIFF
--- a/grafana-button.html
+++ b/grafana-button.html
@@ -853,6 +853,12 @@
                                 newParams.set('theme', 'current');
                             }
 
+                            for (let [key, value] of params.entries()) {
+                                if (key.startsWith('var-')) {
+                                    newParams.set(key, value);
+                                }
+                            }
+
                             return url.origin + url.pathname + (newParams.toString() ? '?' + newParams.toString() : '');
                         }
 


### PR DESCRIPTION
## Fix: PDF export now respects current dashboard variable selections

### 🔧 What was happening:
The generated export URL did not include the var-* parameters representing the current state of the dashboard. As a result, the PDF always used default values.

### ✅ What’s changed:
The filterURL() function was updated to include all var-* parameters from the current URL.

Fixes #28
