### PR TITLE
Fix Chromium temp paths to avoid crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
     environment:
       - PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
       - EXPORT_SERVER_PORT=${EXPORT_SERVER_PORT:-3001}
+      - XDG_CONFIG_HOME=/tmp/.chromium
+      - XDG_CACHE_HOME=/tmp/.chromium


### PR DESCRIPTION
New builds are failing with
```
Starting browser...
Error during PDF generation: Failed to launch the browser process:  Code: null

stderr:
chrome_crashpad_handler: --database is required
Try 'chrome_crashpad_handler --help' for more information.
```
Adding extra ENV variables solves the issue.
Found relevant info [here](https://github.com/hardkoded/puppeteer-sharp/issues/2633#issuecomment-2107557005).